### PR TITLE
Fix bug for exclude in structure

### DIFF
--- a/google_sitemap_lite/ee2/system/expressionengine/third_party/google_sitemap_lite/pi.google_sitemap_lite.php
+++ b/google_sitemap_lite/ee2/system/expressionengine/third_party/google_sitemap_lite/pi.google_sitemap_lite.php
@@ -514,6 +514,11 @@ class Google_sitemap_lite
 						{
 							$entry_id = array_search($uri_segment.'/', $page_uris);
 						}
+
+						if($entry_id == '')
+						{
+							$entry_id = array_search('/'.$uri_segment.'/', $page_uris);
+						}
 					}
 
 					//check on the hidden pages


### PR DESCRIPTION
For whatever reason, Structure sometimes gives back the page_uris as
"/url_title/" instead of "/url_title" or "url_title/". So, when excluding
an entry_id, also search for "/url_title/".
