### PR TITLE
Fix lastmod when using structure bug

### DIFF
--- a/google_sitemap_lite/ee2/system/expressionengine/third_party/google_sitemap_lite/pi.google_sitemap_lite.php
+++ b/google_sitemap_lite/ee2/system/expressionengine/third_party/google_sitemap_lite/pi.google_sitemap_lite.php
@@ -532,9 +532,9 @@ class Google_sitemap_lite
 					
 					//get the last modified data
 					$result = $this->EE->db->get_where('channel_titles', array('entry_id' => $entry_id))->row();
-					if(!empty($date->edit_date))
+					if(!empty($result->edit_date))
 					{
-						$date = date('Y-m-d',$this->EE->localize->timestamp_to_gmt($date->edit_date));
+						 $date = substr($result->edit_date, 0, 4).'-'.substr($result->edit_date, 4, 2).'-'.substr($result->edit_date, 6, 2);
 					}
 					else
 					{


### PR DESCRIPTION
Fix bug where the lastmod is always the current date when using structure.

channel_titles data is put in $result, but then the test checks if $date->edit_date is empty, which it always is.

Furthermore, the edit_date in channel_titles is in a stupid format that’s neither usable as a timestamp or a string through localize methods, e.g. 20160127155023, so let's just use some string manipulations to get it as yyyy-mm-dd.
